### PR TITLE
added feature custom connection callback.

### DIFF
--- a/sqlite3/driver.go
+++ b/sqlite3/driver.go
@@ -16,19 +16,24 @@ import (
 )
 
 // Driver implements the interface required by database/sql.
-type Driver string
+type Driver struct {
+	ConnectCallback func(c *Conn)
+}
 
 func register(name string) {
 	defer func() { recover() }()
-	sql.Register(name, Driver(name))
+	sql.Register(name, &Driver{nil})
 }
 
-func (Driver) Open(name string) (driver.Conn, error) {
+func (d *Driver) Open(name string) (driver.Conn, error) {
 	c, err := Open(name)
 	if err != nil {
 		return nil, err
 	}
 	c.BusyTimeout(5 * time.Second)
+	if d.ConnectCallback != nil {
+		d.ConnectCallback(c)
+	}
 	return &conn{c}, nil
 }
 

--- a/sqlite3/driver.go
+++ b/sqlite3/driver.go
@@ -17,7 +17,7 @@ import (
 
 // Driver implements the interface required by database/sql.
 type Driver struct {
-	ConnectCallback func(c *Conn)
+	ConnectCallback func(c *Conn) error
 }
 
 func register(name string) {
@@ -32,7 +32,9 @@ func (d *Driver) Open(name string) (driver.Conn, error) {
 	}
 	c.BusyTimeout(5 * time.Second)
 	if d.ConnectCallback != nil {
-		d.ConnectCallback(c)
+		if err := d.ConnectCallback(c); err != nil {
+			return nil, err
+		}
 	}
 	return &conn{c}, nil
 }


### PR DESCRIPTION
usage example

``` go
package main

import (
    "database/sql"
    "fmt"
    "github.com/mxk/go-sqlite/sqlite3"
)

func main() {
    sql.Register("sqlite3-hook", &sqlite3.Driver{func(conn *sqlite3.Conn) error {
        fmt.Println("connect:", conn)
        if err := conn.Exec("pragma journal_mode=WAL;" +
            "pragma read_uncommitted=true;" +
            "pragma locking_mode=NORMAL;" +
            "pragma synchronous=FULL;" +
            "pragma busy_timeout=60000;" +
            "pragma cache_spill=true;"); err != nil {
            return err
        }
        return nil
    }})
    db, err := sql.Open("sqlite3-hook", "file:db.sqlite3")
    fmt.Println(db, err)
}
```
